### PR TITLE
Remove deprecated base activity in favor of AppCompatActivity.

### DIFF
--- a/Lesson1/app/src/main/java/com/uw/android310/lesson1/MainActivity.java
+++ b/Lesson1/app/src/main/java/com/uw/android310/lesson1/MainActivity.java
@@ -1,12 +1,12 @@
 package com.uw.android310.lesson1;
 
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 
 
-public class MainActivity extends ActionBarActivity {
+public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
ActionBarActivity is deprecated. Changing the base class for MainActivity to AppCompatActivity instead.

Please see: 
http://stackoverflow.com/questions/23089547/difference-between-extending-activity-and-actionbaractivity
